### PR TITLE
Add an 'about' page

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "tasks": {
+    "launch": "python -m pip install flask && python app.py"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -53,3 +53,6 @@ This Repo should help you to get a simple Python website setup using the Flask f
   - Python: [W3Schools](https://www.w3schools.com/python/)
   - Flask: [Official Docs](https://flask.palletsprojects.com/en/1.1.x/)
 
+## About Page
+- The project now includes an 'About' page.
+- You can access it by navigating to http://127.0.0.1:4949/about or http://localhost:4949/about.

--- a/app.py
+++ b/app.py
@@ -18,6 +18,9 @@ def account():
             usr = "<User Not Defined>"
     return render_template("account.html",username=usr) #rendering our account.html contained within /templates
 
+@app.route("/about") #defining the route for the about() function
+def about():
+    return render_template("about.html") #rendering our about.html contained within /templates
 
 
 if __name__ == "__main__": #checking if __name__'s value is '__main__'. __name__ is an python environment variable who's value will always be '__main__' till this is the first instatnce of app.py running

--- a/templates/about.html
+++ b/templates/about.html
@@ -1,6 +1,6 @@
 {% extends "template.html" %}
 
 {% block body %}
-<h2>About Page</h2>
+<h2>Awesome about Page</h2>
 <p>This is the about page!</p>
 {% endblock %}

--- a/templates/about.html
+++ b/templates/about.html
@@ -1,0 +1,6 @@
+{% extends "template.html" %}
+
+{% block body %}
+<h2>About Page</h2>
+<p>This is the about page!</p>
+{% endblock %}

--- a/templates/template.html
+++ b/templates/template.html
@@ -16,6 +16,11 @@
     </div>
     <div>
         <center>
+            <nav>
+                <a href="/home">Home</a> |
+                <a href="/account">Account</a> |
+                <a href="/about">About</a>
+            </nav>
             {% block body %} {% endblock %}
         </center>
     </div>


### PR DESCRIPTION
Add an 'about' page to the website.

* **app.py**
  - Add a new route for the 'about' page.
  - Define a function to render the 'about' page.

* **templates/about.html**
  - Create a new HTML file extending from `template.html`.
  - Add a heading "About Page".
  - Add a paragraph with one sentence for demo.

* **templates/template.html**
  - Add a link to the 'about' page in the navigation section.

* **README.md**
  - Update to mention the new 'about' page.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mcreutz/python-simple-website/pull/1?shareId=04498d1b-491b-4ca3-b766-780af2ee1acf).